### PR TITLE
Disable colors in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,3 +113,8 @@ def test_dir_read_only():
     yield TEST_DIR_READ_ONLY
     # tear down
     os.chmod(TEST_DIR_READ_ONLY, 0o755)
+
+
+@pytest.fixture(autouse=True)
+def disable_colors(monkeypatch):
+    monkeypatch.setenv("PYTHON_COLORS", "0")


### PR DESCRIPTION
Several tests fail on Python 3.14 due to `argparse` making additional `fileno` calls to check for color support.  This isn't interesting in tests at the moment, so disable it.