### PR TITLE
Avoid including stray packages in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = ["setuptools>=61.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-exclude = ["tests", "tests.*"]
+include = ["yarsync", "yarsync.*"]
 
 # This is the entry-point
 # https://setuptools.pypa.io/en/latest/userguide/entry_point.html

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
         'Tracker': 'https://github.com/ynikitenko/yarsync/issues',
     },
     keywords="distributed, file, synchronization, rsync, backup",
-    packages=setuptools.find_packages(exclude=['tests', 'tests.*']),
+    packages=setuptools.find_packages(include=["yarsync", "yarsync.*"]),
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console", 


### PR DESCRIPTION
In some environments, using `exclude` can result in stray packages ending up in the wheel; for example in a Debian package build that built for each of Python 3.13 and 3.14 in succession, I found that the 3.14 build ended up containing a duplicate `build` directory.  Using `include` is safer.